### PR TITLE
Add basic Thicken plugin structure

### DIFF
--- a/thicken.php
+++ b/thicken.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Plugin Name: Thicken
+ * Description: Provides a rotating random-post RSS feed.
+ * Version: 0.1.0
+ * Author: Thicken Team
+ * License: GPL-2.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain: thicken
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+define('THICKEN_VERSION', '0.1.0');
+define('THICKEN_PLUGIN_FILE', __FILE__);
+
+define('THICKEN_PLUGIN_DIR', __DIR__);
+
+define('THICKEN_PLUGIN_BASENAME', plugin_basename(__FILE__));
+
+final class Thicken_Plugin
+{
+    private static $instance = null;
+
+    private function __construct()
+    {
+        $this->setup_hooks();
+    }
+
+    public static function instance()
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    private function setup_hooks()
+    {
+        register_activation_hook(THICKEN_PLUGIN_FILE, array($this, 'activate'));
+        register_deactivation_hook(THICKEN_PLUGIN_FILE, array($this, 'deactivate'));
+    }
+
+    public function activate()
+    {
+        // Activation logic will be added in later issues.
+    }
+
+    public function deactivate()
+    {
+        // Deactivation logic will be added in later issues.
+    }
+}
+
+Thicken_Plugin::instance();


### PR DESCRIPTION
### Motivation
- Provide the initial scaffold for the Thicken WordPress plugin that will implement a rotating random-post RSS feed.

### Description
- Added `thicken.php` which contains plugin header metadata, constants (`THICKEN_VERSION`, `THICKEN_PLUGIN_FILE`, `THICKEN_PLUGIN_DIR`, `THICKEN_PLUGIN_BASENAME`) and a bootstrap `Thicken_Plugin` class that registers `activate`/`deactivate` hooks.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b5efa52a883279a3fda29e2d54659)