### PR TITLE
Implement Thicken RSS feed with admin settings and transient-based rotation

### DIFF
--- a/admin/class-thicken-admin.php
+++ b/admin/class-thicken-admin.php
@@ -1,0 +1,208 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class Thicken_Admin
+{
+    /** @var Thicken */
+    private $plugin;
+
+    public function __construct($plugin)
+    {
+        $this->plugin = $plugin;
+
+        add_action('admin_menu', array($this, 'register_menu'));
+        add_action('admin_init', array($this, 'register_settings'));
+        add_action('update_option_' . Thicken::OPTION_NAME, array($this, 'handle_option_update'), 10, 2);
+    }
+
+    public function register_menu()
+    {
+        add_options_page(
+            __('Thicken', 'thicken'),
+            __('Thicken', 'thicken'),
+            'manage_options',
+            'thicken-settings',
+            array($this, 'render_settings_page')
+        );
+    }
+
+    public function register_settings()
+    {
+        register_setting(
+            'thicken_settings_group',
+            Thicken::OPTION_NAME,
+            array($this, 'sanitize_settings')
+        );
+
+        add_settings_section(
+            'thicken_main_section',
+            __('Thicken Settings', 'thicken'),
+            array($this, 'render_section_description'),
+            'thicken-settings'
+        );
+
+        add_settings_field(
+            'thicken_post_types',
+            __('Post Types', 'thicken'),
+            array($this, 'render_post_types_field'),
+            'thicken-settings',
+            'thicken_main_section'
+        );
+
+        add_settings_field(
+            'thicken_interval',
+            __('Rotation Interval', 'thicken'),
+            array($this, 'render_interval_field'),
+            'thicken-settings',
+            'thicken_main_section'
+        );
+
+        add_settings_field(
+            'thicken_feed_slug',
+            __('Feed Slug', 'thicken'),
+            array($this, 'render_feed_slug_field'),
+            'thicken-settings',
+            'thicken_main_section'
+        );
+    }
+
+    public function render_section_description()
+    {
+        echo '<p>' . esc_html__('Configure the random-post RSS feed.', 'thicken') . '</p>';
+    }
+
+    public function render_post_types_field()
+    {
+        $settings = $this->plugin->get_settings();
+        $selected = isset($settings['post_types']) ? (array) $settings['post_types'] : array('post');
+        $post_types = get_post_types(array('public' => true), 'objects');
+
+        foreach ($post_types as $post_type) {
+            if ($post_type->name === 'attachment') {
+                continue;
+            }
+
+            $checked = in_array($post_type->name, $selected, true);
+            echo '<label style="display:block; margin-bottom:4px;">';
+            echo '<input type="checkbox" name="' . esc_attr(Thicken::OPTION_NAME) . '[post_types][]" value="' . esc_attr($post_type->name) . '" ' . checked($checked, true, false) . ' />';
+            echo ' ' . esc_html($post_type->labels->singular_name);
+            echo '</label>';
+        }
+    }
+
+    public function render_interval_field()
+    {
+        $settings = $this->plugin->get_settings();
+        $selected = isset($settings['interval']) ? (int) $settings['interval'] : 600;
+        $options = $this->get_interval_options();
+
+        echo '<select name="' . esc_attr(Thicken::OPTION_NAME) . '[interval]">';
+        foreach ($options as $value => $label) {
+            $is_selected = ((int) $value === $selected);
+            echo '<option value="' . esc_attr($value) . '" ' . selected($is_selected, true, false) . '>' . esc_html($label) . '</option>';
+        }
+        echo '</select>';
+    }
+
+    public function render_feed_slug_field()
+    {
+        $settings = $this->plugin->get_settings();
+        $slug = isset($settings['feed_slug']) ? $settings['feed_slug'] : 'random-post';
+
+        echo '<input type="text" class="regular-text" name="' . esc_attr(Thicken::OPTION_NAME) . '[feed_slug]" value="' . esc_attr($slug) . '" />';
+        echo '<p class="description">' . esc_html__('Default: random-post', 'thicken') . '</p>';
+    }
+
+    public function sanitize_settings($input)
+    {
+        $defaults = Thicken::get_default_settings();
+        $output = $defaults;
+
+        $allowed_post_types = $this->get_allowed_post_types();
+        if (isset($input['post_types']) && is_array($input['post_types'])) {
+            $sanitized = array();
+            foreach ($input['post_types'] as $post_type) {
+                $post_type = sanitize_key($post_type);
+                if (in_array($post_type, $allowed_post_types, true)) {
+                    $sanitized[] = $post_type;
+                }
+            }
+            if (!empty($sanitized)) {
+                $output['post_types'] = array_values(array_unique($sanitized));
+            }
+        }
+
+        $interval_options = array_keys($this->get_interval_options());
+        if (isset($input['interval'])) {
+            $interval = (int) $input['interval'];
+            if (in_array($interval, $interval_options, true)) {
+                $output['interval'] = $interval;
+            }
+        }
+
+        if (isset($input['feed_slug'])) {
+            $slug = sanitize_title($input['feed_slug']);
+            $output['feed_slug'] = $slug !== '' ? $slug : $defaults['feed_slug'];
+        }
+
+        return $output;
+    }
+
+    public function handle_option_update($old_value, $new_value)
+    {
+        $old_value = is_array($old_value) ? $old_value : array();
+        $new_value = is_array($new_value) ? $new_value : array();
+
+        $old_value = wp_parse_args($old_value, Thicken::get_default_settings());
+        $new_value = wp_parse_args($new_value, Thicken::get_default_settings());
+
+        if ($old_value['feed_slug'] !== $new_value['feed_slug']) {
+            flush_rewrite_rules();
+        }
+
+        if ($old_value['interval'] !== $new_value['interval'] || $old_value['post_types'] !== $new_value['post_types']) {
+            delete_transient(Thicken::TRANSIENT_KEY);
+        }
+    }
+
+    public function render_settings_page()
+    {
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+
+        include THICKEN_PLUGIN_DIR . '/admin/views/settings-page.php';
+    }
+
+    private function get_interval_options()
+    {
+        return array(
+            600 => __('10 minutes', 'thicken'),
+            1200 => __('20 minutes', 'thicken'),
+            1800 => __('30 minutes', 'thicken'),
+            3600 => __('60 minutes', 'thicken'),
+            10800 => __('3 hours', 'thicken'),
+            21600 => __('6 hours', 'thicken'),
+            43200 => __('12 hours', 'thicken'),
+            86400 => __('24 hours', 'thicken'),
+        );
+    }
+
+    private function get_allowed_post_types()
+    {
+        $post_types = get_post_types(array('public' => true), 'objects');
+        $allowed = array();
+
+        foreach ($post_types as $post_type) {
+            if ($post_type->name === 'attachment') {
+                continue;
+            }
+            $allowed[] = $post_type->name;
+        }
+
+        return $allowed;
+    }
+}

--- a/admin/views/settings-page.php
+++ b/admin/views/settings-page.php
@@ -1,0 +1,27 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$settings = $this->plugin->get_settings();
+$feed_slug = isset($settings['feed_slug']) ? $settings['feed_slug'] : 'random-post';
+$feed_url = trailingslashit(home_url()) . 'feed/' . $feed_slug;
+
+?>
+<div class="wrap">
+    <h1><?php echo esc_html__('Thicken Settings', 'thicken'); ?></h1>
+
+    <p>
+        <?php echo esc_html__('Feed URL:', 'thicken'); ?>
+        <code><?php echo esc_html($feed_url); ?></code>
+    </p>
+
+    <form method="post" action="options.php">
+        <?php
+        settings_fields('thicken_settings_group');
+        do_settings_sections('thicken-settings');
+        submit_button();
+        ?>
+    </form>
+</div>

--- a/includes/class-thicken-feed.php
+++ b/includes/class-thicken-feed.php
@@ -1,0 +1,144 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class Thicken_Feed
+{
+    /** @var Thicken */
+    private $plugin;
+
+    public function __construct($plugin)
+    {
+        $this->plugin = $plugin;
+    }
+
+    public function render_feed()
+    {
+        $settings = $this->plugin->get_settings();
+        $post_types = isset($settings['post_types']) ? (array) $settings['post_types'] : array('post');
+        $interval = isset($settings['interval']) ? (int) $settings['interval'] : 600;
+        if ($interval <= 0) {
+            $interval = 600;
+        }
+
+        $post_id = $this->get_cached_post_id($post_types, $interval);
+        $post = $post_id ? get_post($post_id) : null;
+        if ($post && $post->post_status !== 'publish') {
+            delete_transient(Thicken::TRANSIENT_KEY);
+            $post = null;
+        }
+
+        $charset = get_option('blog_charset');
+        header('Content-Type: application/rss+xml; charset=' . $charset, true);
+
+        echo '<?xml version="1.0" encoding="' . esc_attr($charset) . '"?>';
+        echo "\n";
+        echo '<rss version="2.0">';
+        echo "\n";
+        echo '<channel>';
+        echo "\n";
+        echo '<title>' . esc_html(get_bloginfo('name')) . '</title>';
+        echo "\n";
+        echo '<link>' . esc_url(get_bloginfo('url')) . '</link>';
+        echo "\n";
+        echo '<description>' . esc_html(get_bloginfo('description')) . '</description>';
+        echo "\n";
+        echo '<lastBuildDate>' . esc_html(gmdate(DATE_RSS)) . '</lastBuildDate>';
+        echo "\n";
+
+        if ($post) {
+            $title = get_the_title($post);
+            $link = get_permalink($post);
+            $description = $this->get_post_description($post);
+            $pub_date = get_post_time(DATE_RSS, true, $post);
+
+            echo '<item>';
+            echo "\n";
+            echo '<title>' . esc_html($title) . '</title>';
+            echo "\n";
+            echo '<link>' . esc_url($link) . '</link>';
+            echo "\n";
+            echo '<pubDate>' . esc_html($pub_date) . '</pubDate>';
+            echo "\n";
+            echo '<guid isPermaLink="true">' . esc_url($link) . '</guid>';
+            echo "\n";
+            echo '<description>' . esc_html($description) . '</description>';
+            echo "\n";
+            echo '</item>';
+            echo "\n";
+        }
+
+        echo '</channel>';
+        echo "\n";
+        echo '</rss>';
+        exit;
+    }
+
+    private function get_cached_post_id($post_types, $interval)
+    {
+        $cached = get_transient(Thicken::TRANSIENT_KEY);
+        if ($cached !== false) {
+            return (int) $cached;
+        }
+
+        $post_id = $this->get_random_post_id($post_types);
+        if ($post_id) {
+            set_transient(Thicken::TRANSIENT_KEY, $post_id, $interval);
+        }
+
+        return $post_id;
+    }
+
+    private function get_random_post_id($post_types)
+    {
+        $post_types = array_values(array_filter($post_types, 'post_type_exists'));
+        if (empty($post_types)) {
+            return 0;
+        }
+
+        $count_query = new WP_Query(array(
+            'post_type' => $post_types,
+            'post_status' => 'publish',
+            'posts_per_page' => 1,
+            'fields' => 'ids',
+        ));
+
+        $total = (int) $count_query->found_posts;
+        if ($total < 1) {
+            return 0;
+        }
+
+        $offset = $total > 1 ? wp_rand(0, $total - 1) : 0;
+
+        $random_query = new WP_Query(array(
+            'post_type' => $post_types,
+            'post_status' => 'publish',
+            'posts_per_page' => 1,
+            'fields' => 'ids',
+            'orderby' => 'date',
+            'order' => 'DESC',
+            'offset' => $offset,
+        ));
+
+        if (empty($random_query->posts)) {
+            return 0;
+        }
+
+        return (int) $random_query->posts[0];
+    }
+
+    private function get_post_description($post)
+    {
+        if (has_excerpt($post->ID)) {
+            $excerpt = get_the_excerpt($post);
+            return wp_trim_words(wp_strip_all_tags($excerpt), 55);
+        }
+
+        $content = $post->post_content ? $post->post_content : '';
+        $content = wp_strip_all_tags($content);
+
+        return wp_trim_words($content, 55);
+    }
+}

--- a/includes/class-thicken.php
+++ b/includes/class-thicken.php
@@ -1,0 +1,88 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class Thicken
+{
+    const OPTION_NAME = 'thicken_settings';
+    const TRANSIENT_KEY = 'thicken_random_post_id';
+
+    private static $instance = null;
+
+    /** @var Thicken_Admin */
+    private $admin;
+
+    /** @var Thicken_Feed */
+    private $feed;
+
+    public static function instance()
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    private function __construct()
+    {
+        $this->feed = new Thicken_Feed($this);
+
+        if (is_admin()) {
+            $this->admin = new Thicken_Admin($this);
+        }
+
+        add_action('init', array($this, 'register_feed'));
+    }
+
+    public static function activate()
+    {
+        $defaults = self::get_default_settings();
+        if (!get_option(self::OPTION_NAME)) {
+            add_option(self::OPTION_NAME, $defaults);
+        }
+
+        flush_rewrite_rules();
+    }
+
+    public static function deactivate()
+    {
+        flush_rewrite_rules();
+    }
+
+    public function register_feed()
+    {
+        $slug = $this->get_feed_slug();
+        add_feed($slug, array($this->feed, 'render_feed'));
+    }
+
+    public static function get_default_settings()
+    {
+        return array(
+            'post_types' => array('post'),
+            'interval' => 600,
+            'feed_slug' => 'random-post',
+        );
+    }
+
+    public function get_settings()
+    {
+        $settings = get_option(self::OPTION_NAME, array());
+        if (!is_array($settings)) {
+            $settings = array();
+        }
+
+        return wp_parse_args($settings, self::get_default_settings());
+    }
+
+    public function get_feed_slug()
+    {
+        $settings = $this->get_settings();
+        $slug = isset($settings['feed_slug']) ? $settings['feed_slug'] : 'random-post';
+        $slug = sanitize_title($slug);
+
+        return $slug !== '' ? $slug : 'random-post';
+    }
+}

--- a/thicken.php
+++ b/thicken.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Thicken
  * Description: Provides a rotating random-post RSS feed.
- * Version: 0.1.0
+ * Version: 1.0.0
  * Author: Thicken Team
  * License: GPL-2.0-or-later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -13,46 +13,16 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-define('THICKEN_VERSION', '0.1.0');
+define('THICKEN_VERSION', '1.0.0');
 define('THICKEN_PLUGIN_FILE', __FILE__);
-
 define('THICKEN_PLUGIN_DIR', __DIR__);
-
 define('THICKEN_PLUGIN_BASENAME', plugin_basename(__FILE__));
 
-final class Thicken_Plugin
-{
-    private static $instance = null;
+require_once THICKEN_PLUGIN_DIR . '/includes/class-thicken.php';
+require_once THICKEN_PLUGIN_DIR . '/includes/class-thicken-feed.php';
+require_once THICKEN_PLUGIN_DIR . '/admin/class-thicken-admin.php';
 
-    private function __construct()
-    {
-        $this->setup_hooks();
-    }
+register_activation_hook(THICKEN_PLUGIN_FILE, array('Thicken', 'activate'));
+register_deactivation_hook(THICKEN_PLUGIN_FILE, array('Thicken', 'deactivate'));
 
-    public static function instance()
-    {
-        if (self::$instance === null) {
-            self::$instance = new self();
-        }
-
-        return self::$instance;
-    }
-
-    private function setup_hooks()
-    {
-        register_activation_hook(THICKEN_PLUGIN_FILE, array($this, 'activate'));
-        register_deactivation_hook(THICKEN_PLUGIN_FILE, array($this, 'deactivate'));
-    }
-
-    public function activate()
-    {
-        // Activation logic will be added in later issues.
-    }
-
-    public function deactivate()
-    {
-        // Deactivation logic will be added in later issues.
-    }
-}
-
-Thicken_Plugin::instance();
+Thicken::instance();


### PR DESCRIPTION
### Motivation
- Provide a dedicated RSS feed that returns one randomly-rotated published post and allow site admins to configure which post types, rotation interval, and feed slug. 
- Persist selection for a configurable interval so repeated requests return the same item during the interval using the Transients API. 
- Expose configuration via the WordPress Settings API and ensure rewrite rules and transients are managed when settings change.

### Description
- Add plugin bootstrap in `thicken.php` and wire activation/deactivation to the core `Thicken` class. 
- Add `includes/class-thicken.php` implementing plugin core behavior, default settings, feed registration, activation/deactivation hooks, and helper getters for settings and feed slug. 
- Add `includes/class-thicken-feed.php` which renders a valid RSS2 feed (one <item> max) with `title`, `link`, `pubDate`, `guid`, and `description`, sets `Content-Type: application/rss+xml; charset=blog_charset`, and selects a random published post via WP_Query using a count+offset approach (avoids `ORDER BY RAND`) and caches the selected post ID using `set_transient`/`get_transient`. 
- Add `admin/class-thicken-admin.php` which registers a settings page (`Settings → Thicken`) using the Settings API with fields for post types (checkboxes), rotation interval (select), and feed slug (text), performs sanitization/validation, and flushes rewrite rules or clears the transient when relevant settings change. 
- Add `admin/views/settings-page.php` view to render the settings UI and display the feed URL. 
- Default behavior: feed slug `random-post`, default post types `['post']`, default interval `600` seconds (10 minutes). Selection excludes `attachment` post type and handles zero-result cases by returning an empty (but valid) RSS feed. 

### Testing
- Automated tests: none were executed for this change (no CI tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b6b0604cc8327930b0b67ffd679a8)