### PR TITLE
Improve random post selection and settings safety

### DIFF
--- a/admin/class-thicken-admin.php
+++ b/admin/class-thicken-admin.php
@@ -118,6 +118,10 @@ final class Thicken_Admin
 
     public function sanitize_settings($input)
     {
+        if (!current_user_can('manage_options')) {
+            return $this->plugin->get_settings();
+        }
+
         $defaults = Thicken::get_default_settings();
         $output = $defaults;
 


### PR DESCRIPTION
### Motivation

- Reduce heavy `ORDER BY RAND`/offset-based queries when selecting a random published post across selected post types to improve performance on large sites.
- Prevent unauthorized users from modifying plugin settings by enforcing capability checks during sanitization.

### Description

- Replace offset-based `WP_Query` random selection with an ID-range lookup using `global $wpdb` to `SELECT MIN(ID), MAX(ID)` and then pick a random ID in range with a nearest-available `SELECT ID ... ORDER BY ID ASC LIMIT 1` and a descending fallback; changes in `includes/class-thicken-feed.php` (method `get_random_post_id`).
- Add a capability guard to `sanitize_settings` so only users with `manage_options` can apply settings changes; changes in `admin/class-thicken-admin.php`.
- Preserve transient caching (`Thicken::TRANSIENT_KEY`) and existing behaviors for feed rendering, feed slug handling, and transient deletion on relevant option updates.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b8308a5008327831707032a3535b6)