### PR TITLE
Validate cached transient post and reseed when invalid

### DIFF
--- a/includes/class-thicken-feed.php
+++ b/includes/class-thicken-feed.php
@@ -80,7 +80,12 @@ final class Thicken_Feed
     {
         $cached = get_transient(Thicken::TRANSIENT_KEY);
         if ($cached !== false) {
-            return (int) $cached;
+            $cached_id = (int) $cached;
+            if ($this->is_valid_cached_post($cached_id, $post_types)) {
+                return $cached_id;
+            }
+
+            delete_transient(Thicken::TRANSIENT_KEY);
         }
 
         $post_id = $this->get_random_post_id($post_types);
@@ -89,6 +94,33 @@ final class Thicken_Feed
         }
 
         return $post_id;
+    }
+
+    private function is_valid_cached_post($post_id, $post_types)
+    {
+        if (!$post_id) {
+            return false;
+        }
+
+        $post_types = array_values(array_filter($post_types, 'post_type_exists'));
+        if (empty($post_types)) {
+            return false;
+        }
+
+        $post = get_post($post_id);
+        if (!$post) {
+            return false;
+        }
+
+        if ($post->post_status !== 'publish') {
+            return false;
+        }
+
+        if (!in_array($post->post_type, $post_types, true)) {
+            return false;
+        }
+
+        return true;
     }
 
     private function get_random_post_id($post_types)


### PR DESCRIPTION
### Motivation
- Prevent the random-post RSS from returning empty when a cached post ID was later deleted, unpublished, or no longer an allowed `post_type`.
- Ensure the transient is reselected within the same request if the cached entry is invalid so the feed remains functional.

### Description
- Update `get_cached_post_id` to validate the cached transient and delete it when invalid, then reseed once by calling the existing `get_random_post_id` and `set_transient` if a new post is found.
- Add a new helper method `is_valid_cached_post` that checks the post exists, has `post_status === 'publish'`, and its `post_type` is in the allowed `post_types` list (using `post_type_exists` to normalize types).
- Keep existing reselection logic and limit changes to a single-file, minimal, non-breaking modification to `includes/class-thicken-feed.php`.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bbd32af5c83278559c2371871ed08)