### PR TITLE
Add category-aware random-post feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ https://example.com/feed/random-post
 
 ※ フィードスラッグは管理画面から変更可能です。
 
+カテゴリ別フィードURL（カテゴリースラッグを使用）：
+
+https://example.com/category/{category-slug}/feed/random-post
+
+※ スラッグ変更時は `/feed/{設定したスラッグ}` に置き換えてください。
+
 ---
 
 ## 動作の仕組み

--- a/admin/class-thicken-admin.php
+++ b/admin/class-thicken-admin.php
@@ -167,8 +167,11 @@ final class Thicken_Admin
             flush_rewrite_rules();
         }
 
-        if ($old_value['interval'] !== $new_value['interval'] || $old_value['post_types'] !== $new_value['post_types']) {
-            delete_transient(Thicken::TRANSIENT_KEY);
+        if ($old_value['interval'] !== $new_value['interval'] || $old_value['post_types'] !== $new_value['post_types'] || $old_value['feed_slug'] !== $new_value['feed_slug']) {
+            $old_key = $this->plugin->build_transient_key($old_value, 0);
+            $new_key = $this->plugin->build_transient_key($new_value, 0);
+            delete_transient($old_key);
+            delete_transient($new_key);
         }
     }
 


### PR DESCRIPTION
### Motivation
- Provide category-scoped random RSS feeds using the existing feed slug when the feed is requested from a category archive, while keeping the existing global feed behavior unchanged. 
- Keep caching/rotation semantics (Transients API, configured intervals, selected post types) but ensure global and per-category caches do not collide. 

### Description
- Updated `includes/class-thicken.php` to replace the single transient key constant with a transient key prefix and added `get_transient_key()` / `build_transient_key()` to produce settings-aware keys that include a category context. 
- Enhanced `includes/class-thicken-feed.php` to detect category context (`get_query_var('cat')`, `get_queried_object()`, `is_category()`), build a per-term transient key, and pass `term_id` into the cache/selection logic; added term-aware validation and category-limited random selection (joins on term tables) so only published posts in that category are considered. 
- Updated `admin/class-thicken-admin.php` to clear the appropriate transients when relevant settings change by calling the new key builder for old/new settings. 
- Updated `README.md` with a brief note describing the category feed URL pattern (`/category/{category-slug}/feed/{feed-slug}`), noting the feed slug is configurable. 
- Preserved existing output rules: RSS2, single `<item>`, fields `title/link/pubDate/guid/description`, transients-based rotation using existing interval and post type settings, and returning an empty RSS when no posts are found. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981c01121b48327a01179ed8389e491)