### PR TITLE
Move Thicken settings to top-level admin menu

### DIFF
--- a/admin/class-thicken-admin.php
+++ b/admin/class-thicken-admin.php
@@ -20,12 +20,14 @@ final class Thicken_Admin
 
     public function register_menu()
     {
-        add_options_page(
+        add_menu_page(
             __('Thicken', 'thicken'),
             __('Thicken', 'thicken'),
             'manage_options',
             'thicken-settings',
-            array($this, 'render_settings_page')
+            array($this, 'render_settings_page'),
+            'dashicons-rss',
+            70
         );
     }
 


### PR DESCRIPTION
### Motivation
- Expose the Thicken settings as a top-level admin menu so it appears in the left sidebar (like RE:Access) instead of under `Settings` for easier access.

### Description
- Replace `add_options_page` with `add_menu_page` in `admin/class-thicken-admin.php`, preserving the menu slug `thicken-settings` and capability `manage_options`, and add the `dashicons-rss` icon with menu position `70`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981eff42f208327a70ea8d28c447a98)