### PR TITLE
Add permalink element to RSS items

### DIFF
--- a/includes/class-thicken-feed.php
+++ b/includes/class-thicken-feed.php
@@ -64,6 +64,7 @@ final class Thicken_Feed
             $link = get_permalink($post);
             $description = $this->get_post_description($post);
             $pub_date = get_post_time(DATE_RSS, true, $post);
+            $permalink = get_permalink($post);
 
             echo '<item>';
             echo "\n";
@@ -74,6 +75,8 @@ final class Thicken_Feed
             echo '<pubDate>' . esc_html($pub_date) . '</pubDate>';
             echo "\n";
             echo '<guid isPermaLink="true">' . esc_url($link) . '</guid>';
+            echo "\n";
+            echo '<permalink>' . esc_url($permalink) . '</permalink>';
             echo "\n";
             echo '<description>' . esc_html($description) . '</description>';
             echo "\n";


### PR DESCRIPTION
### Motivation
- The RSS <item> output was missing the required `<permalink>` element from the spec, so feeds didn't include an explicit permalink tag for the selected post.

### Description
- Added a `permalink` element to the RSS item output in `includes/class-thicken-feed.php` by calling `get_permalink($post)` and echoing `<permalink>` between `<guid>` and `<description>` to minimally satisfy the spec.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698270703ad883278b1a1b1795e51522)